### PR TITLE
fix link of the traffic-signal java implementation.

### DIFF
--- a/problems/traffic-signal.md
+++ b/problems/traffic-signal.md
@@ -13,7 +13,7 @@
 ![](../class-diagrams/trafficsignalsystem-class-diagram.png)
 
 ## Implementations
-#### [Java Implementation](../solutions/java/src/trafficsignalsystem/) 
+#### [Java Implementation](../solutions/java/src/trafficsignalcontrolsystem/)
 #### [Python Implementation](../solutions/python/trafficsignalsystem/)
 #### [C++ Implementation](../solutions/cpp/trafficsignalsystem/)
 #### [C# Implementation](../solutions/csharp/trafficsignalsystem/)


### PR DESCRIPTION
The link to the java implementation of traffic control system was broken. 

Updating it with the correct source file