### PR TITLE
Java Parking Lot - Fix duplicate key removal

### DIFF
--- a/solutions/java/src/parkinglot/ParkingLot.java
+++ b/solutions/java/src/parkinglot/ParkingLot.java
@@ -69,7 +69,6 @@ public class ParkingLot {
 
         ticket.setExitTimestamp();
         ticket.getSpot().unparkVehicle();
-        activeTickets.remove(ticket.getTicketId());
 
         Double parkingFee = feeStrategy.calculateFee(ticket);
 


### PR DESCRIPTION
activeTickets is keyed by license number and is removed by license number at the beginning of the method. There is then a redundant call to remove by ticket id which I have removed.