### PR TITLE
Fix broken image references in solution READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This repository contains resources to learn Low Level Design (LLD) / Object Orie
 - [Design Parking Lot](problems/parking-lot.md) 🟢
 - [Design Stack Overflow](problems/stack-overflow.md) 🟢
 - [Design a Vending Machine](problems/vending-machine.md) 🟢
-- [Design Logging Framework](problems/logging-framework.md)
+- [Design Logging Framework](problems/logging-framework.md) 🟢
 - [Design Traffic Signal Control System](problems/traffic-signal.md)
 - [Design Coffee Vending Machine](problems/coffee-vending-machine.md)
 - [Design a Task Management System](problems/task-management-system.md)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This repository contains resources to learn Low Level Design (LLD) / Object Orie
 
 - [Design Parking Lot](problems/parking-lot.md) 🟢
 - [Design Stack Overflow](problems/stack-overflow.md) 🟢
-- [Design a Vending Machine](problems/vending-machine.md)
+- [Design a Vending Machine](problems/vending-machine.md) 🟢
 - [Design Logging Framework](problems/logging-framework.md)
 - [Design Traffic Signal Control System](problems/traffic-signal.md)
 - [Design Coffee Vending Machine](problems/coffee-vending-machine.md)

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ This repository contains resources to learn Low Level Design (LLD) / Object Orie
 ## 💻 Low Level Design Interview Problems
 ### Easy Problems
 
-- [Design Parking Lot](problems/parking-lot.md)
-- [Design Stack Overflow](problems/stack-overflow.md)
+- [Design Parking Lot](problems/parking-lot.md) 🟢
+- [Design Stack Overflow](problems/stack-overflow.md) 🟢
 - [Design a Vending Machine](problems/vending-machine.md)
 - [Design Logging Framework](problems/logging-framework.md)
 - [Design Traffic Signal Control System](problems/traffic-signal.md)

--- a/problems/traffic-signal.md
+++ b/problems/traffic-signal.md
@@ -10,7 +10,7 @@
 
 ## UML Class Diagram
 
-![](../class-diagrams/trafficsignalsystem-class-diagram.png)
+![](../class-diagrams/trafficcontrolsystem-class-diagram.png)
 
 ## Implementations
 #### [Java Implementation](../solutions/java/src/trafficsignalcontrolsystem/)

--- a/solutions/java/src/airlinemanagementsystem/README.md
+++ b/solutions/java/src/airlinemanagementsystem/README.md
@@ -34,7 +34,7 @@ Design and implement an Airline Management System that allows users to book flig
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/airlinemanagementsystem-class-diagram.png)
+![](../../../../class-diagrams/airlinemanagementsystem-class-diagram.png)
 
 ### 1. AirlineManagementSystem
 

--- a/solutions/java/src/atm/README.md
+++ b/solutions/java/src/atm/README.md
@@ -38,7 +38,7 @@ Design and implement an ATM (Automated Teller Machine) system that allows users 
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/atmSystem-class-diagram.png)
+![](../../../../class-diagrams/atmSystem-class-diagram.png)
 
 ### 1. ATM
 - **Fields:** BankingService bankService, CashDispenser cashDispenser

--- a/solutions/java/src/carrentalsystem/README.md
+++ b/solutions/java/src/carrentalsystem/README.md
@@ -12,7 +12,7 @@
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/carrentalsystem-class-diagram.png)
+![](../../../../class-diagrams/carrentalsystem-class-diagram.png)
 
 ## Classes, Interfaces and Enumerations
 1. The **Car** class represents a car in the rental system, with properties such as make, model, year, license plate number, rental price per day, and availability status.

--- a/solutions/java/src/chessgame/README.md
+++ b/solutions/java/src/chessgame/README.md
@@ -37,7 +37,7 @@ Design and implement a Chess Game that allows two players to play chess on a sta
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/chessgame-class-diagram.png)
+![](../../../../class-diagrams/chessgame-class-diagram.png)
 
 ### 1. ChessGame
 - **Fields:** Board board, Player[] players, int currentPlayerIndex, boolean isGameOver

--- a/solutions/java/src/coffeevendingmachine/README.md
+++ b/solutions/java/src/coffeevendingmachine/README.md
@@ -31,7 +31,7 @@ Design and implement a Coffee Vending Machine system that can serve different ty
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/coffeevendingmachine-class-diagram.png)
+![](../../../../class-diagrams/coffeevendingmachine-class-diagram.png)
 
 ### 1. CoffeeVendingMachine
 - **Fields:** ingredientStore, paymentProcessor, Map<String, CoffeeRecipe> recipes, Dispenser

--- a/solutions/java/src/concertticketbookingsystem/README.md
+++ b/solutions/java/src/concertticketbookingsystem/README.md
@@ -33,7 +33,7 @@ Design and implement a Concert Ticket Booking System that allows users to book s
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/concertticketbookingsystem-class-diagram.png)
+![](../../../../class-diagrams/concertticketbookingsystem-class-diagram.png)
 
 ### 1. ConcertTicketBookingSystem
 - **Fields:** List<Concert> concerts, List<Booking> bookings

--- a/solutions/java/src/courseregistrationsystem/README.md
+++ b/solutions/java/src/courseregistrationsystem/README.md
@@ -21,7 +21,7 @@ Design and implement a Course Registration System that allows students to regist
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/CourseRegistrationSystem-class-diagram.png)
+![](../../../../class-diagrams/CourseRegistrationSystem-class-diagram.png)
 
 - **CourseRegistrationSystem:** Main class that manages students, courses, and registrations.
 - **Student:** Represents a student with a unique ID and name.

--- a/solutions/java/src/cricinfo/README.md
+++ b/solutions/java/src/cricinfo/README.md
@@ -72,7 +72,7 @@ Design and implement a Cricket Information System similar to CricInfo that provi
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/cricinfo-class-diagram.png)
+![](../../../../class-diagrams/cricinfo-class-diagram.png)
 
 ---
 

--- a/solutions/java/src/digitalwalletservice/README.md
+++ b/solutions/java/src/digitalwalletservice/README.md
@@ -76,7 +76,7 @@ Design and implement a Digital Wallet Service that allows users to manage their 
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/digitalwalletservice-class-diagram.png)
+![](../../../../class-diagrams/digitalwalletservice-class-diagram.png)
 
 ## Example Usage
 

--- a/solutions/java/src/elevatorsystem/README.md
+++ b/solutions/java/src/elevatorsystem/README.md
@@ -44,7 +44,7 @@ Design and implement an Elevator System that can handle multiple requests, move 
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/elevatorsystem-class-diagram.png)
+![](../../../../class-diagrams/elevatorsystem-class-diagram.png)
 
 ---
 

--- a/solutions/java/src/fooddeliveryservice/README.md
+++ b/solutions/java/src/fooddeliveryservice/README.md
@@ -34,7 +34,7 @@ Design and implement a Food Delivery Service system that allows customers to pla
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/fooddeliveryservice-class-diagram.png)
+![](../../../../class-diagrams/fooddeliveryservice-class-diagram.png)
 
 ### 1. FoodDeliveryService
 - **Fields:** List<Customer> customers, List<Restaurant> restaurants, List<DeliveryAgent> agents, List<Order> orders

--- a/solutions/java/src/hotelmanagementsystem/README.md
+++ b/solutions/java/src/hotelmanagementsystem/README.md
@@ -79,7 +79,7 @@ Design and implement a Hotel Management System that manages hotel rooms, reserva
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/HotelManagementSystem-class-diagram.png)
+![](../../../../class-diagrams/HotelManagementSystem-class-diagram.png)
 
 ---
 

--- a/solutions/java/src/librarymanagementsystem/README.md
+++ b/solutions/java/src/librarymanagementsystem/README.md
@@ -32,7 +32,7 @@ Design and implement a Library Management System that allows members to borrow a
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/LibraryManagementSystem-class-diagram.png)
+![](../../../../class-diagrams/LibraryManagementSystem-class-diagram.png)
 
 ### 1. LibraryManagementSystem
 - **Fields:** List<Book> books, List<Member> members, List<Loan> loans, Catalog catalog

--- a/solutions/java/src/linkedin/README.md
+++ b/solutions/java/src/linkedin/README.md
@@ -38,7 +38,7 @@ Design and implement a LinkedIn-like professional networking platform that allow
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/linkedin-class-diagram.png)
+![](../../../../class-diagrams/linkedin-class-diagram.png)
 
 ### 1. LinkedInService
 - **Fields:** List<User> users, List<JobPosting> jobPostings, List<Connection> connections, List<Notification> notifications

--- a/solutions/java/src/loggingframework/README.md
+++ b/solutions/java/src/loggingframework/README.md
@@ -33,7 +33,7 @@ Design and implement a flexible and extensible logging framework that can be use
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/loggingframework-class-diagram.png)
+![](../../../../class-diagrams/loggingframework-class-diagram.png)
 
 ### 1. Logger
 - **Methods:**

--- a/solutions/java/src/lrucache/README.md
+++ b/solutions/java/src/lrucache/README.md
@@ -26,7 +26,7 @@ Design and implement an LRU (Least Recently Used) Cache with a fixed capacity. T
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/lrucache-class-diagram.png)
+![](../../../../class-diagrams/lrucache-class-diagram.png)
 
 ### 1. LRUCache
 - **Fields:** capacity, Map<K, Node<K, V>>, head/tail pointers for the doubly-linked list

--- a/solutions/java/src/movieticketbookingsystem/README.md
+++ b/solutions/java/src/movieticketbookingsystem/README.md
@@ -75,7 +75,7 @@ Design and implement a Movie Ticket Booking System that allows users to book mov
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/MovieTicketBookingSystem-class-diagram.png)
+![](../../../../class-diagrams/MovieTicketBookingSystem-class-diagram.png)
 ---
 
 ## Example Usage

--- a/solutions/java/src/musicstreamingservice/README.md
+++ b/solutions/java/src/musicstreamingservice/README.md
@@ -39,7 +39,7 @@ Design and implement an online music streaming service (like Spotify) that allow
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/musicstreamingservice-class-diagram.png)
+![](../../../../class-diagrams/musicstreamingservice-class-diagram.png)
 
 ### 1. Song
 - **Fields:** int id, String title, Artist artist, Album album, int duration

--- a/solutions/java/src/onlineauctionsystem/README.md
+++ b/solutions/java/src/onlineauctionsystem/README.md
@@ -33,7 +33,7 @@ Design and implement an Online Auction System that allows users to create auctio
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/onlineauctionsystem-class-diagram.png)
+![](../../../../class-diagrams/onlineauctionsystem-class-diagram.png)
 
 ### 1. AuctionSystem
 - **Fields:** List<User> users, List<Item> items, List<Auction> auctions

--- a/solutions/java/src/onlineshoppingservice/README.md
+++ b/solutions/java/src/onlineshoppingservice/README.md
@@ -36,7 +36,7 @@ Design and implement an Online Shopping Service that allows users to browse prod
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/OnlineShoppingService-class-diagram.png)
+![](../../../../class-diagrams/OnlineShoppingService-class-diagram.png)
 
 ### 1. OnlineShoppingService
 - **Fields:** List<User> users, List<Product> products, List<Order> orders, PaymentProcessor paymentProcessor

--- a/solutions/java/src/onlinestockbrokeragesystem/README.md
+++ b/solutions/java/src/onlinestockbrokeragesystem/README.md
@@ -99,7 +99,7 @@ Design and implement an Online Stock Brokerage System that allows users to buy a
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/onlineStockBrokerageSystem-class-diagram.png)
+![](../../../../class-diagrams/onlineStockBrokerageSystem-class-diagram.png)
 ---
 
 ## Example Usage

--- a/solutions/java/src/parkinglot/README.md
+++ b/solutions/java/src/parkinglot/README.md
@@ -34,7 +34,7 @@ Design and implement a Parking Lot Management System that supports parking and u
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/parkinglot-class-diagram.png)
+![](../../../../class-diagrams/parkinglot-class-diagram.png)
 
 ### 1. ParkingLot
 - **Methods:**

--- a/solutions/java/src/pubsubsystem/README.md
+++ b/solutions/java/src/pubsubsystem/README.md
@@ -35,7 +35,7 @@ Design and implement a Publish-Subscribe (Pub/Sub) system that allows publishers
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/pubsubsystem-class-diagram.png)
+![](../../../../class-diagrams/pubsubsystem-class-diagram.png)
 
 ### 1. Broker
 - **Fields:** Map<String, Topic> topics

--- a/solutions/java/src/restaurantmanagementsystem/README.md
+++ b/solutions/java/src/restaurantmanagementsystem/README.md
@@ -39,7 +39,7 @@ Design and implement a Restaurant Management System that allows customers to mak
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/RestaurantManagementSystem-class-diagram.png)
+![](../../../../class-diagrams/RestaurantManagementSystem-class-diagram.png)
 
 ### 1. RestaurantManagementSystem
 - **Fields:** List<Table> tables, List<Reservation> reservations, List<MenuItem> menu, List<Order> orders, List<Bill> bills, List<Staff> staff, PaymentProcessor paymentProcessor

--- a/solutions/java/src/ridesharingservice/README.md
+++ b/solutions/java/src/ridesharingservice/README.md
@@ -37,7 +37,7 @@ Design and implement a Ride Sharing Service that allows riders to request rides,
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/RideSharingService-class-diagram.png)
+![](../../../../class-diagrams/RideSharingService-class-diagram.png)
 
 ### 1. RideSharingService
 - **Fields:** List<Rider> riders, List<Driver> drivers, List<Trip> trips, PaymentProcessor paymentProcessor

--- a/solutions/java/src/snakeandladdergame/README.md
+++ b/solutions/java/src/snakeandladdergame/README.md
@@ -34,7 +34,7 @@ Design and implement a Snake and Ladder Game that allows multiple players to pla
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/SnakeAndLadderGame-class-diagram.png)
+![](../../../../class-diagrams/SnakeAndLadderGame-class-diagram.png)
 
 ### 1. SnakeAndLadderGame
 - **Fields:** Board board, List<Player> players, Dice dice, boolean isGameOver

--- a/solutions/java/src/splitwise/README.md
+++ b/solutions/java/src/splitwise/README.md
@@ -80,7 +80,7 @@ Design and implement a Splitwise System that allows users to split expenses amon
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/splitwise-class-diagram.png)
+![](../../../../class-diagrams/splitwise-class-diagram.png)
 
 ---
 

--- a/solutions/java/src/stackoverflow/README.md
+++ b/solutions/java/src/stackoverflow/README.md
@@ -36,7 +36,7 @@ Design and implement a simplified StackOverflow-like Q&A platform. The system sh
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/stackoverflow-class-diagram.png)
+![](../../../../class-diagrams/stackoverflow-class-diagram.png)
 
 ### 1. User
 - **Fields:** id, name, reputation, etc.

--- a/solutions/java/src/taskmanagementsystem/README.md
+++ b/solutions/java/src/taskmanagementsystem/README.md
@@ -34,7 +34,7 @@ Design and implement a Task Management System that allows users to create, assig
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/taskmanagementsystem-class-diagram.png)
+![](../../../../class-diagrams/taskmanagementsystem-class-diagram.png)
 
 ### 1. Task
 - **Fields:** id, title, description, status, priority, assignee (User), List<Comment>

--- a/solutions/java/src/tictactoe/README.md
+++ b/solutions/java/src/tictactoe/README.md
@@ -33,7 +33,7 @@ Design and implement a Tic Tac Toe game that allows two players to play on a NxN
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/tictactoe-class-diagram.png)
+![](../../../../class-diagrams/tictactoe-class-diagram.png)
 
 ### 1. Game
 - **Fields:** Board board, Player[] players, int currentPlayerIndex, GameStatus status

--- a/solutions/java/src/trafficsignalcontrolsystem/README.md
+++ b/solutions/java/src/trafficsignalcontrolsystem/README.md
@@ -33,7 +33,7 @@ Design and implement a Traffic Signal System to manage the traffic lights at an 
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/trafficsignalsystem-class-diagram.png)
+![](../../../../class-diagrams/trafficsignalsystem-class-diagram.png)
 
 ### 1. Direction
 - Enum: NORTH, SOUTH, EAST, WEST

--- a/solutions/java/src/vendingmachine/README.md
+++ b/solutions/java/src/vendingmachine/README.md
@@ -33,7 +33,7 @@ Design and implement a Vending Machine system that allows users to select produc
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/vendingmachine-class-diagram.png)
+![](../../../../class-diagrams/vendingmachine-class-diagram.png)
 
 ### 1. VendingMachine
 - **Fields:** Inventory inventory, VendingMachineState idleState, readyState, dispenseState, returnChangeState, currentState, Product selectedProduct, double totalPayment

--- a/solutions/java/src/votingsystem/README.md
+++ b/solutions/java/src/votingsystem/README.md
@@ -30,7 +30,7 @@ Design and implement a Voting System that allows voters to cast votes for candid
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/votingsystem-class-diagram.png)
+![](../../../../class-diagrams/votingsystem-class-diagram.png)
 
 ### 1. VotingSystem
 

--- a/solutions/typescript/src/CoffeeVendingMachine/README.md
+++ b/solutions/typescript/src/CoffeeVendingMachine/README.md
@@ -31,7 +31,7 @@ Design and implement a Coffee Vending Machine system that can serve different ty
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/coffeevendingmachine-class-diagram.png)
+![](../../../../class-diagrams/coffeevendingmachine-class-diagram.png)
 
 ### 1. CoffeeVendingMachine
 - **Fields:** ingredientStore, paymentProcessor, Map<String, CoffeeRecipe> recipes, Dispenser

--- a/solutions/typescript/src/LoggingFramework/README.md
+++ b/solutions/typescript/src/LoggingFramework/README.md
@@ -33,7 +33,7 @@ Design and implement a flexible and extensible logging framework that can be use
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/loggingframework-class-diagram.png)
+![](../../../../class-diagrams/loggingframework-class-diagram.png)
 
 ### 1. Logger
 - **Methods:**

--- a/solutions/typescript/src/StackOverflow/README.md
+++ b/solutions/typescript/src/StackOverflow/README.md
@@ -36,7 +36,7 @@ Design and implement a simplified StackOverflow-like Q&A platform. The system sh
 
 ## UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/stackoverflow-class-diagram.png)
+![](../../../../class-diagrams/stackoverflow-class-diagram.png)
 
 ### 1. User
 - **Fields:** id, name, reputation, etc.

--- a/solutions/typescript/src/TaskManagement/README.md
+++ b/solutions/typescript/src/TaskManagement/README.md
@@ -34,7 +34,7 @@ Design and implement a Task Management System that allows users to create, assig
 
 ### UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/taskmanagementsystem-class-diagram.png)
+![](../../../../class-diagrams/taskmanagementsystem-class-diagram.png)
 
 ### 1. Task
 - **Fields:** id, title, description, status, priority, assignee (User), List<Comment>

--- a/solutions/typescript/src/TrafficSignalSystem/README.md
+++ b/solutions/typescript/src/TrafficSignalSystem/README.md
@@ -33,7 +33,7 @@ Design and implement a Traffic Signal System to manage the traffic lights at an 
 
 ### UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/trafficsignalsystem-class-diagram.png)
+![](../../../../class-diagrams/trafficsignalsystem-class-diagram.png)
 
 ### 1. Direction
 - Enum: NORTH, SOUTH, EAST, WEST

--- a/solutions/typescript/src/VendingMachine/README.md
+++ b/solutions/typescript/src/VendingMachine/README.md
@@ -33,7 +33,7 @@ Design and implement a Vending Machine system that allows users to select produc
 
 ### UML Class Diagram
 
-![](../../../../uml-diagrams/class-diagrams/vendingmachine-class-diagram.png)
+![](../../../../class-diagrams/vendingmachine-class-diagram.png)
 
 ### 1. VendingMachine
 - **Fields:** Inventory inventory, VendingMachineState idleState, readyState, dispenseState, returnChangeState, currentState, Product selectedProduct, double totalPayment


### PR DESCRIPTION
## Summary

- Found 39 broken image references across Java and TypeScript solution README files
- All references pointed to a non-existent `uml-diagrams/class-diagrams/` directory
- Fixed by correcting the paths to the actual `class-diagrams/` directory at the repo root

**Pattern fixed:**
```
../../../../uml-diagrams/class-diagrams/filename.png  ❌
../../../../class-diagrams/filename.png               ✅
```

**Affected files:** 33 Java solution READMEs + 6 TypeScript solution READMEs

## Test plan
- [ ] Verify class diagram images render correctly in the affected README files
- [ ] Spot-check a few files: `solutions/java/src/parkinglot/README.md`, `solutions/typescript/src/VendingMachine/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)