### PR TITLE
Fix traffic control system's UML path in traffic-signal.md

### DIFF
--- a/problems/traffic-signal.md
+++ b/problems/traffic-signal.md
@@ -10,7 +10,7 @@
 
 ## UML Class Diagram
 
-![](../class-diagrams/trafficsignalsystem-class-diagram.png)
+![](../class-diagrams/trafficcontrolsystem-class-diagram.png)
 
 ## Implementations
 #### [Java Implementation](../solutions/java/src/trafficsignalcontrolsystem/)


### PR DESCRIPTION
There was a typo in the path to the UML diagram of the traffic control system. Fixed it appropriately.