### PR TITLE
Add TutorialSearch to 📇 Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This repository contains resources to learn Low Level Design (LLD) / Object Orie
 ## 📇 Courses
 - [Master LLD Interviews - AlgoMaster.io](https://algomaster.io/learn/lld/course-introduction)
 - [Master Concurrency Interviews - AlgoMaster.io](https://algomaster.io/learn/concurrency-interview)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## 📚 Books
 - [Head First Design Patterns](https://www.amazon.in/dp/9385889753)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *📇 Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.