### PR TITLE
Fix traffic control system UML link

### DIFF
--- a/problems/traffic-signal.md
+++ b/problems/traffic-signal.md
@@ -10,7 +10,7 @@
 
 ## UML Class Diagram
 
-![](../class-diagrams/trafficsignalsystem-class-diagram.png)
+![](../class-diagrams/trafficcontrolsystem-class-diagram.png)
 
 ## Implementations
 #### [Java Implementation](../solutions/java/src/trafficsignalcontrolsystem/)


### PR DESCRIPTION
Previously the Traffic control system md file was pointing to a wrong image file, fixed the url link.