### PR TITLE
Update README to replace 'vendingMachineState' with 'signalState'

### DIFF
--- a/solutions/java/src/trafficsignalcontrolsystem/README.md
+++ b/solutions/java/src/trafficsignalcontrolsystem/README.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Design and implement a Traffic Signal System to manage the traffic lights at an intersection. The system should support configurable signal durations for each direction and vendingMachineState, automatic cycling of signals using the State design pattern, and the ability to manually override signals as needed.
+Design and implement a Traffic Signal System to manage the traffic lights at an intersection. The system should support configurable signal durations for each direction and signalState, automatic cycling of signals using the State design pattern, and the ability to manually override signals as needed.
 
 ---
 
@@ -10,20 +10,20 @@ Design and implement a Traffic Signal System to manage the traffic lights at an 
 
 - **Multiple Directions:** The intersection supports multiple directions (e.g., NORTH, SOUTH, EAST, WEST).
 - **Traffic Light States:** Each direction has a traffic light with states: GREEN, YELLOW, RED.
-- **Configurable Durations:** Each direction and vendingMachineState can have its own configurable duration.
+- **Configurable Durations:** Each direction and signalState can have its own configurable duration.
 - **Automatic Cycling:** The system automatically cycles through the states for each direction in a round-robin fashion.
 - **Manual Override:** The system allows manual override to set a specific direction to GREEN at any time.
 - **Extensibility:** Easy to add new directions or states if needed.
-- **State Pattern:** Use the State design pattern to encapsulate vendingMachineState-specific behavior and transitions.
+- **State Pattern:** Use the State design pattern to encapsulate signalState-specific behavior and transitions.
 
 ---
 
 ## Core Entities
 
 - **Direction:** Enum representing the directions at the intersection (NORTH, SOUTH, EAST, WEST).
-- **SignalState (interface):** Represents the vendingMachineState of a traffic light (GREEN, YELLOW, RED), with vendingMachineState-specific behavior.
-- **GreenState, YellowState, RedState:** Concrete implementations of `SignalState` for each light vendingMachineState.
-- **TrafficLight:** Represents a traffic light for a direction, maintains its current vendingMachineState and delegates behavior to the vendingMachineState.
+- **SignalState (interface):** Represents the signalState of a traffic light (GREEN, YELLOW, RED), with signalState-specific behavior.
+- **GreenState, YellowState, RedState:** Concrete implementations of `SignalState` for each light signalState.
+- **TrafficLight:** Represents a traffic light for a direction, maintains its current signalState and delegates behavior to the signalState.
 - **Intersection:** Represents the intersection, holds all traffic lights and their configurations, and exposes the manual override.
 - **TrafficSignalController:** Controls the cycling and overriding of traffic signals, manages timing and transitions using a scheduler.
 
@@ -61,16 +61,16 @@ Design and implement a Traffic Signal System to manage the traffic lights at an 
 
 ## Design Patterns Used
 
-- **State Pattern:** Each signal vendingMachineState (GREEN, YELLOW, RED) encapsulates its own behavior and transition logic.
+- **State Pattern:** Each signal signalState (GREEN, YELLOW, RED) encapsulates its own behavior and transition logic.
 - **Scheduler/Timer:** For handling timed transitions between states.
-- **Strategy Pattern:** (Conceptually) for supporting different timing strategies per direction/vendingMachineState.
+- **Strategy Pattern:** (Conceptually) for supporting different timing strategies per direction/signalState.
 
 ---
 
 ## Example Usage
 
 ```java
-// Configure durations per direction and vendingMachineState
+// Configure durations per direction and signalState
 Map<Direction, Map<String, Integer>> signalDurations = new EnumMap<>(Direction.class);
 signalDurations.put(Direction.NORTH, Map.of("GREEN", 4, "YELLOW", 2, "RED", 3));
 signalDurations.put(Direction.SOUTH, Map.of("GREEN", 3, "YELLOW", 2, "RED", 4));
@@ -102,7 +102,7 @@ See `TrafficSignalSystemDemo.java` for a sample usage and simulation of the traf
 ## Extending the Framework
 
 - **Add new directions:** Add to the `Direction` enum and update configuration.
-- **Add new states:** Add to the `SignalState` interface and implement new vendingMachineState classes.
+- **Add new states:** Add to the `SignalState` interface and implement new signalState classes.
 - **Custom timing strategies:** Implement new strategies for special intersections or adaptive signals.
 
 ---


### PR DESCRIPTION
## Fix: Replace `vendingMachineState` with `state` in Traffic Signal System documentation

### Problem
The `trafficsignalcontrolsystem` README contains multiple instances of `vendingMachineState` which appears to be a copy-paste artifact from the Vending Machine LLD solution. This is inconsistent with the actual class design, which correctly uses `SignalState` throughout.

### Changes
- Replaced all occurrences of `vendingMachineState` with `state` in `README.md` under `trafficsignalcontrolsystem`

### No logic changes — documentation fix only.