### PR TITLE
fix(typescript): enforce singleton pattern with private constructor  …

### DIFF
--- a/solutions/typescript/src/ParkingLot/ParkingLot.ts
+++ b/solutions/typescript/src/ParkingLot/ParkingLot.ts
@@ -8,7 +8,7 @@ class ParkingLot {
   name : string;
   protected carSpotMap: Record<string,ParkingSpot> 
 
-  constructor(name: string){
+  private constructor(name: string){
     this.name = name
     this.floors = []
     this.carSpotMap = {}
@@ -26,6 +26,7 @@ class ParkingLot {
       const availableSpot = floor.findAvailableSpot(vehicle)
       if(availableSpot){
         availableSpot.parkCar(vehicle)
+        this.carSpotMap[vehicle.getNumber()] = availableSpot
         console.log(`${vehicle.getNumber()} parked on ${availableSpot.spotName}`)
         return 
       }


### PR DESCRIPTION
The readme.md for the TypeScript Parking Lot problem states that the ParkingLot class must strictly follow the Singleton pattern.

This PR addresses two fixes in ParkingLot.ts:

1.Marks the constructor as private to properly enforce the Singleton pattern and prevent external instantiation via new.

2.Updates this.carSpotMap with the availableSpot when a vehicle is successfully parked, ensuring the tracking map functions correctly.